### PR TITLE
MOB-224: if the domain is https the cart cookie is set wrong because …

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -22,14 +22,14 @@ if (settings.affiliateId === 'miintomobile') {
 		// staging 
 		// key: {countryCode}devmiinokie
 		// domain: .dk.sta.miinto.net
-		let hostname = settings.baseUrl.replace(/http:\/\//, '');
+		let hostname = settings.baseUrl.replace(/https?:\/\//, '');
 		tokenCookieKey          = hostname.split('.').shift() + 'devmiinookie';
 		cookieOptions['domain'] = '.' + hostname;
 		
 	} else {
 		// prod
 		// key: {countryCode}miinookie
-		let hostname = settings.baseUrl.replace(/http:\/\//, '').replace(/www\./, '');
+		let hostname = settings.baseUrl.replace(/https?:\/\//, '').replace(/www\./, '');
 		tokenCookieKey          = hostname.split('.').pop() + 'miinookie';
 		cookieOptions['domain'] = '.' + hostname;
 	}


### PR DESCRIPTION
…the https is not removed, only http is supported now. This removes https also, adds support for http and https

What this code change does:

"https://www.miinto.nl".replace(/https?:\/\//, '')
= "www.miinto.nl"

"http://www.miinto.nl".replace(/https?:\/\//, '')
= "www.miinto.nl"